### PR TITLE
🔧 Make CircleCI run our tests when we push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,23 @@
+references:
+  install_bundler: &install_bundler
+    run:
+      name: Install bundler
+      command: gem install bundler:2.3.10
+  setup: &setup
+    run:
+      name: Set up the environment
+      command: bin/setup
+  run_tests: &run_tests
+    run:
+      name: Run the test suite
+      command: COVERAGE=true bin/rake
+
+jobs:
+  build:
+    docker:
+      - image: "cimg/ruby:3.0.1"
+    steps:
+      - checkout
+      - <<: *install_bundler
+      - <<: *setup
+      - <<: *run_tests


### PR DESCRIPTION
Before, we had not set up a CI service for the repository. When developers pushed their changes, they had no idea if they had broken the app or not. We made CircleCI run the entire suite whenever we added a change to GitHub.