### PR TITLE
🔧 Make spec_helper to be required

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper


### PR DESCRIPTION
This is needed to remove the need to  always write "require
spec_helper" for every new test file that is written.

The side effect is that as a developer, you won't have to always write
the line "require spec_helper" at the top of every test file that you
write.

Co-authored-by: Rob Whittaker <rob@thoughtbot.com>
