### PR TITLE
🔧 Make system tests run in a headless browser

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,8 @@
+version: 2.1
+
+orbs:
+  browser-tools: circleci/browser-tools@1.4.0
+
 references:
   install_bundler: &install_bundler
     run:
@@ -15,8 +20,10 @@ references:
 jobs:
   build:
     docker:
-      - image: "cimg/ruby:3.0.1"
+      - image: "cimg/ruby:3.0.1-browsers"
     steps:
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - checkout
       - <<: *install_bundler
       - <<: *setup

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,5 +1,4 @@
 //= link_tree ../images
 //= link_directory ../stylesheets .css
 //= link_tree ../../javascript .js
-//= link_tree ../../../vendor/javascript .js
 //= link_tree ../builds

--- a/bin/setup
+++ b/bin/setup
@@ -23,7 +23,7 @@ FileUtils.chdir APP_ROOT do
   # end
 
   puts "\n== Preparing database =="
-  system! "bin/rails db:prepare"
+  system! "bin/rails db:setup"
 
   puts "\n== Removing old logs and tempfiles =="
   system! "bin/rails log:clear tmp:clear"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,21 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 2022_06_23_155325) do
+  create_table "articles", force: :cascade do |t|
+    t.string "title", null: false
+    t.text "content", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+ENV['RAILS_ENV'] ||= 'test'
+
+require_relative '../config/environment'
+
+abort("The Rails environment is running in production mode!") if Rails.env.production?
+
+require 'rspec/rails'
+require "capybara/rails"
+
+Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |file| require file }
+
+begin
+  ActiveRecord::Migration.maintain_test_schema!
+rescue ActiveRecord::PendingMigrationError => e
+  puts e.to_s.strip
+  exit 1
+end
+
+RSpec.configure do |config|
+  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.use_transactional_fixtures = true
+  config.infer_spec_type_from_file_location!
+  config.filter_rails_from_backtrace!
+end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end

--- a/spec/support/chromedriver.rb
+++ b/spec/support/chromedriver.rb
@@ -1,0 +1,27 @@
+require "selenium/webdriver"
+
+Capybara.register_driver :chrome do |app|
+  Capybara::Selenium::Driver.new(app, browser: :chrome)
+end
+
+Capybara.register_driver :headless_chrome do |app|
+  options = ::Selenium::WebDriver::Chrome::Options.new
+  options.headless!
+  options.add_argument "--window-size=1680,1050"
+
+  Capybara::Selenium::Driver.new app,
+    browser: :chrome,
+    options: options
+end
+
+Capybara.javascript_driver = :headless_chrome
+
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    driven_by :rack_test
+  end
+
+  config.before(:each, type: :system, js: true) do
+    driven_by Capybara.javascript_driver
+  end
+end


### PR DESCRIPTION
Before, we had not set up the tests to run in a headless browser. The CI build failed as soon as we ran a system test. We made the tests run without the need for the browser chrome.

- Refactored the database setup.
- Dropped unnecessary JavaScript directory.

[Trello][]

[trello]: https://trello.com/c/vNjOSsLn/25-make-ci-run-with-an-image-with-a-browser
