### PR TITLE
🔧 Make Heroku run migrations on release

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bin/rails server -p $PORT
+release: bin/auto_migrate

--- a/bin/auto_migrate
+++ b/bin/auto_migrate
@@ -1,0 +1,5 @@
+set -e
+
+if [ -n "$AUTO_MIGRATE_DB"  ]; then
+  bundle exec rake db:migrate
+fi


### PR DESCRIPTION
Before, we had to run the migrations by hand whenever we deployed to Heroku. This opens up to potential errors. We made Heroku run the migrations every time we release.
