### PR TITLE
🔧 Add deploy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,14 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+
+## Deploying
+
+If you have previously run the `./bin/setup` script, you can deploy to staging
+and production with:
+
+```shell
+./bin/deploy staging
+./bin/deploy production
+```

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Run this script to deploy the app to Heroku.
+
+set -e
+
+branch="$(git symbolic-ref HEAD --short)"
+target="${1:-staging}"
+
+git push "$target" "$branch:main"


### PR DESCRIPTION
Before, we were having to recall or look up the Heroku commands in order
to initiate a deplpy to the server.
This is intended to simplify the deployment process.
