### PR TITLE
🚨 Add system test to check if navigation is hidden

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,8 +12,14 @@
   </head>
 
   <body>
-    <nav class="crumbs">
-    </nav>
+    <% unless current_page?(sign_in_path) %>
+      <nav class="crumbs">
+          <ul>
+              <li class="crumb"><a href="#"><%= t(".title") %></a></li>
+              <li class="crumb"><%= link_to t(".sign_in"), sign_in_path %></li>
+          </ul>
+      </nav>
+    <% end %>
     <main>
       <% if signed_in? %>
         Signed in as: <%= current_user.email %>

--- a/spec/system/clearance/visitor_signs_in_spec.rb
+++ b/spec/system/clearance/visitor_signs_in_spec.rb
@@ -2,6 +2,11 @@ require "rails_helper"
 require "support/features/clearance_helpers"
 
 RSpec.feature "Visitor signs in" do
+  scenario "navigation is hidden" do
+    visit sign_in_path
+    expect(page).not_to have_link("Sign in", href: sign_in_path)
+  end
+
   scenario "with valid email and password" do
     create_user "user@example.com", "password"
     sign_in_with "user@example.com", "password"


### PR DESCRIPTION
Before, we had a navigation menu that would always show on every page
including the sign in page.
This was rather destructive.

Now, we have a test that checks if the sign in link is on the sign in
page and if it is, we are hiding it together with the rest of the
navigation menu.
