### PR TITLE
🌐 Add translations to the nav menu

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,10 +25,10 @@
               <ul class="flex items-center">
                 <% if signed_in? %>
                   <li class="mb-1">
-                    Hello: <%= current_user.email %>
+                    <%= t(".greeting", email: current_user.email) %>
                   </li>
                   <li class="mb-1">
-                    <%= button_to 'Sign out', sign_out_path, method: :delete,
+                    <%= button_to t(".sign_out"), sign_out_path, method: :delete,
                     class:"p-4 border-b-2 border-purple-500 border-opacity-0
                     hover:border-opacity-100 hover:text-purple-500
                     duration-200 cursor-pointer active" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,3 +46,7 @@ en:
   sessions:
     new:
       application_name: "Rumblr"
+  layouts:
+    application:
+      title: "Rumblr"
+      greeting: "Hello: %{email}"  


### PR DESCRIPTION
The title, user greeting and sign out button on the nav menu weren't
setup to have translations.
This change introduces translations for them.

