### PR TITLE
♻️  Change title to point to the root path

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,8 +16,8 @@
       <div class="header sticky top-0 bg-white shadow-md flex
                     items-center px-8 py-02 h-16 flow-root">
         <div class="float-left mt-3">
-          <a class="p-2 text-3xl" href="#">
-            <%= t(".title") %>
+          <a class="p-2">
+            <%= link_to t(".title"), root_path, class: "text-3xl" %>
           </a>
         </div>
         <div class="float-right">


### PR DESCRIPTION
Before, we had the title leading no where. We have made a change to make
title lead to the root path when clicked.
