### PR TITLE
🎨 Style sign up page to have a consistent layout

### DIFF
--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,9 +1,10 @@
 <div class="text-field">
-  <%= form.label :email %>
-  <%= form.email_field :email %>
+  <%= form.label :email, class: "block font-semibold" %>
+  <%= form.email_field :email, class: "email-input", placeholder: "Email"%>
 </div>
 
 <div class="password-field">
-  <%= form.label :password %>
-  <%= form.password_field :password %>
+  <%= form.label :password, class: "block mt-3 font-semibold" %>
+  <%= form.password_field :password, class: "password-input",
+    placeholder: "Password"%>
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,15 +1,23 @@
-<div id="clearance" class="sign-up">
-  <h2><%= t(".title") %></h2>
+<div class="new-signin-form">
+  <div class="relative py-3 sm:w-96 mx-auto text-center">
+    <span class="text-2xl font-light "><%= t(".title") %></span>
 
-  <%= form_for @user do |form| %>
-    <%= render partial: '/users/form', object: form %>
+    <div class="mt-4 bg-white shadow-md rounded-lg text-left">
+      <div class="h-2 bg-purple-400 rounded-t-md"></div>
+        <div class="px-8 py-6 mb-24">
+          <%= form_for @user do |form| %>
+            <%= render partial: '/users/form', object: form %>
 
-    <div class="submit-field">
-      <%= form.submit %>
+            <div class="submit-field">
+              <%= form.submit class: "purple-btn w-80" %>
+            </div>
+
+            <div class="mt-3">
+              <%= link_to t(".sign_in"), sign_in_path, class: "text-base
+              hover:underline" %>
+            </div>
+          <% end %>
+        <div>
     </div>
-
-    <div class="other-links">
-      <%= link_to t(".sign_in"), sign_in_path %>
-    </div>
-  <% end %>
+  </div>
 </div>


### PR DESCRIPTION
The signup page looked awful and everything was all over the place.
We have moved the different elements on the page to make it look better.

Sign up page before the change:
![Sign up before](https://user-images.githubusercontent.com/3297508/225558520-c0494fa0-6958-4193-8260-2650b5a83f2d.jpg)

Sign up page after the change:
![Sign up after](https://user-images.githubusercontent.com/3297508/225558613-1ac1d866-f467-4621-a4e3-75b6b9c8dbe4.jpg)

