### PR TITLE
🎨 Align sign in link on the nav bar

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,7 @@
                   </li>
                 <% else %>
                   <li class="mb-1">
-                    <%= link_to t(".sign_in"), sign_in_path,
+                    <%= button_to t(".sign_in"), sign_in_path,
                     class:"p-4 border-b-2 border-purple-500 border-opacity-0
                     hover:border-opacity-100 hover:text-purple-500
                     duration-200 cursor-pointer active" %>


### PR DESCRIPTION
The sign-in link on the nav bar was slightly off, so things didn't look
good.

We have made changes to align the link with the rest of the items on the
nav bar so that it now looks good.

Sign-in link before the change:
![Sign in link before](https://user-images.githubusercontent.com/3297508/225928940-f4740ff1-b196-4285-8c32-51bd0cdb1ef9.jpg)


Sign-in link after the change:
![Sign-in link after](https://user-images.githubusercontent.com/3297508/225929211-0bd30986-a765-48e6-aa6a-da3aa299f312.jpg)


