### PR TITLE
🎨 Add validation errors on the sign up page

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -29,5 +29,8 @@
     @apply bg-red-100 border border-red-400 text-red-700 
     px-4 py-3 rounded relative;
   }
+  .form_error {
+    @apply text-red-400;
+  }
 }
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,8 @@
 module ApplicationHelper
+  def field_with_errors(object, field)
+    if object.errors[field].any?
+      error_messages = object.errors.full_messages_for(field).join(", ")
+      content_tag :div, error_messages, class: "form_error"
+    end
+  end
 end

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,10 +1,12 @@
 <div class="text-field">
   <%= form.label :email, class: "block font-semibold" %>
   <%= form.email_field :email, class: "email-input", placeholder: "Email"%>
+  <%= field_with_errors(@user, :email) %>
 </div>
 
 <div class="password-field">
   <%= form.label :password, class: "block mt-3 font-semibold" %>
   <%= form.password_field :password, class: "password-input",
     placeholder: "Password"%>
+  <%= field_with_errors(@user, :password) %>
 </div>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,24 +1,33 @@
 require "rails_helper"
 
 RSpec.describe ApplicationHelper, "#field_with_error" do
+  it "there are no errors" do
+    user = create(:user)
+
+    field_error = helper.field_with_errors(user, :email)
+
+    expect(field_error).to be_nil
+  end
+
   context "when the field has an error" do
     it "returns div with email error" do
       user = create(:user)
-      user.errors.add(:email, "can't be blank")
       user.errors.add(:email, "is invalid")
-      field_error = helper.field_with_errors(user, :email).tr('"', "'")
-      result =
-        "<div class='form_error'>Email can&#39;t be blank, Email is invalid</div>"
+      user.errors.add(:email, "is too long")
 
+      field_error = helper.field_with_errors(user, :email)
+
+      result = '<div class="form_error">Email is invalid, Email is too long</div>'
       expect(field_error).to eq result
     end
 
     it "returns div with password error" do
       user = create(:user)
-      user.errors.add(:password, "can't be blank")
-      field_error = helper.field_with_errors(user, :password).tr('"', "'")
-      result = "<div class='form_error'>Password can&#39;t be blank</div>"
+      user.errors.add(:password, "cannot be blank")
 
+      field_error = helper.field_with_errors(user, :password)
+
+      result = '<div class="form_error">Password cannot be blank</div>'
       expect(field_error).to eq result
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe ApplicationHelper, "#field_with_error" do
+  context "when the field has an error" do
+    it "returns div with email error" do
+      user = create(:user)
+      user.errors.add(:email, "can't be blank")
+      user.errors.add(:email, "is invalid")
+      field_error = helper.field_with_errors(user, :email).tr('"', "'")
+      result =
+        "<div class='form_error'>Email can&#39;t be blank, Email is invalid</div>"
+
+      expect(field_error).to eq result
+    end
+
+    it "returns div with password error" do
+      user = create(:user)
+      user.errors.add(:password, "can't be blank")
+      field_error = helper.field_with_errors(user, :password).tr('"', "'")
+      result = "<div class='form_error'>Password can&#39;t be blank</div>"
+
+      expect(field_error).to eq result
+    end
+  end
+end


### PR DESCRIPTION
When a user attempts to sign up without providing email and password,
there were no validation errors displayed to notify them of the issue.

We have made changes to the UI so the user can get to know what went
wrong.
