### PR TITLE
🎨 Style forgot password page

### DIFF
--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -1,16 +1,23 @@
-<div id="clearance" class="password-reset">
-  <h2><%= t(".title") %></h2>
+<div class="relative py-3 mx-auto max-w-lg my-4">
+  <div class="max-w-lg rounded overflow-hidden shadow-lg p-20 mb-80">
+    <div id="clearance" class="password-reset">
+      <div class="card-header py-3">
+        <h1 class="font-bold uppercase text-2xl"><%= t(".title") %></h1>
+      </div>
+      <div class="my-8">
+        <%= t(".description") %>
+      </div>
 
-  <p><%= t(".description") %></p>
-
-  <%= form_for :password, url: passwords_path do |form| %>
-    <div class="text-field">
-      <%= form.label :email %>
-      <%= form.email_field :email %>
+      <%= form_for :password, url: passwords_path do |form| %>
+        <div class="my-2">
+          <%= form.label :email, class: "font-bold" %>
+          <%= form.text_field :email, class: "w-full mt-2 p-3 rounded-lg
+          focus:outline-none focus:shadow-outline" %>
+        </div>
+        <div class="submit-field">
+          <%= form.submit class: "purple-btn w-full mt-9 p-2" %>
+        </div>
+      <% end %>
     </div>
-
-    <div class="submit-field">
-      <%= form.submit %>
-    </div>
-  <% end %>
+  </div>
 </div>


### PR DESCRIPTION
The forgot password page wasn't looking good. So we made some changes to
move the different elements on the page to be placed in the appropriate
place.

This greatly improves visibility.

Forgot password page before:
![Forgot password before](https://user-images.githubusercontent.com/3297508/229756787-de18720f-196c-4218-971a-ad2a952ab9ac.jpg)


Forgot password page after:
![Forgot password after](https://user-images.githubusercontent.com/3297508/229757133-fb1d90e7-bca5-4e3f-b330-7f1a2499351f.jpg)


