### PR TITLE
✨ Limit edit article to the user who created it

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,10 +1,12 @@
 class ArticlesController < ApplicationController
+  before_action :set_article, only: [:show, :edit, :update]
+
   def new
     @article = Article.new
   end
 
   def create
-    @article = Article.new(article_params)
+    @article = current_user.articles.new(article_params)
 
     if @article.save
       redirect_to @article, notice: t(".success")
@@ -14,16 +16,12 @@ class ArticlesController < ApplicationController
   end
 
   def show
-    @article = Article.find(params[:id])
   end
 
   def edit
-    @article = Article.find(params[:id])
   end
 
   def update
-    @article = Article.find(params[:id])
-
     if @article.update(article_params)
       redirect_to @article, notice: t(".success")
     else
@@ -32,6 +30,10 @@ class ArticlesController < ApplicationController
   end
 
   private
+
+  def set_article
+    @article = current_user.articles.find(params[:id])
+  end
 
   def article_params
     params.require(:article).permit(:title, :content)

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,4 +1,5 @@
 class Article < ApplicationRecord
   validates_presence_of :title
   validates_presence_of :content
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,4 @@
 class User < ApplicationRecord
   include Clearance::User
+  has_many :articles
 end

--- a/db/migrate/20230505095856_add_user_to_article.rb
+++ b/db/migrate/20230505095856_add_user_to_article.rb
@@ -1,0 +1,5 @@
+class AddUserToArticle < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :articles, :user, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_25_091634) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_05_095856) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_25_091634) do
     t.text "content", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_articles_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -33,4 +35,5 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_25_091634) do
     t.index ["remember_token"], name: "index_users_on_remember_token", unique: true
   end
 
+  add_foreign_key "articles", "users"
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -5,4 +5,7 @@ RSpec.describe Article do
     it { should validate_presence_of(:title) }
     it { should validate_presence_of(:content) }
   end
+  describe "associations" do
+    it { should belong_to(:user) }
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+RSpec.describe User do
+  describe "associations" do
+    it { should have_many(:articles) }
+  end
+end

--- a/spec/system/user_creates_an_article_spec.rb
+++ b/spec/system/user_creates_an_article_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "User creates an article" do
 
     expect(page).to have_content "Article was successfully created"
     article = Article.last
+    expect(article.user_id).to eq(user.id)
     expect(page).to have_content "Article ##{article.id}"
     expect(page).to have_content article.title
     expect(page).to have_content article.content


### PR DESCRIPTION
Before, any user could log in and be able to edit an article that they
didn't create.
We have made changes so that an article belongs to a user.
So, a user can only edit articles that they created.
