### PR TITLE
🎨 Restyle landing page flash message

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -26,11 +26,14 @@
     @apply bg-red-300 text-red-900;
   }
   .flash {
-    @apply bg-red-100 border border-red-400 text-red-700 
-    px-4 py-3 rounded relative;
+    @apply bg-red-100 border border-red-400 text-red-700
+    px-4 py-3 w-fit rounded relative;
   }
   .form_error {
     @apply text-red-400;
+  }
+  .center-div {
+    @apply flex justify-center items-center mt-6;
   }
 }
 

--- a/app/views/application/_flashes.html.erb
+++ b/app/views/application/_flashes.html.erb
@@ -1,7 +1,9 @@
 <% if flash.any? %>
-  <div class="flash" role="alert">
-    <% user_facing_flashes.each do |key, value| -%>
-      <div class="font-bold flash-<%= key %>"><%= value %></div>
-    <% end -%>
+  <div class="center-div">
+    <div class="flash" role="alert">
+      <% user_facing_flashes.each do |key, value| -%>
+        <div class="font-bold flash-<%= key %>"><%= value %></div>
+      <% end -%>
+    </div>
   </div>
 <% end %>


### PR DESCRIPTION
We have changed the flash message to be centered in the page.
The flash message was previously spanning the entire width of the page
