### PR TITLE
Change the readme file content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,14 @@
-# README
+# Rumblr
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+This is an implementation of Tumblr using RoR. This project is being used to
+improve and learn the best practices of software development.
+These have been covered so far:
+1. TDD
+2. SOLID principles
+3. RSpec
+4. Git rebasing
+5. Continuous Integration and Continuous Deployment
 
-Things you may want to cover:
-
-* Ruby version
-
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
-
-
-## Deploying
-
-If you have previously run the `./bin/setup` script, you can deploy to staging
-and production with:
-
-```shell
-./bin/deploy staging
-./bin/deploy production
-```
+## Installation
+1. Clone the repo
+2. Run `bin/setup`


### PR DESCRIPTION
Previously, the readme file was generic and it wasn't clear what the project was about.
Changes have been made to include information about the project and how to set up the project locally.
This should be more informative to a new person who stumbles on the project.
