### PR TITLE
Fix forgot password functionality

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,0 +1,9 @@
+class PasswordsController < Clearance::PasswordsController
+  def find_user_by_id_and_confirmation_token
+    user_param = Clearance.configuration.user_id_parameter
+    token = params[:token] || session[:password_reset_token]
+
+    Clearance.configuration.user_model
+      .find_by(slug: params[user_param], confirmation_token: token.to_s)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,13 @@ Rails.application.routes.draw do
   resources :users
   resources :authors, only: :show
 
+  resources :users,
+    only: Clearance.configuration.user_actions do
+      resource :password,
+        controller: "passwords",
+        only: [:edit, :update]
+    end
+
   constraints Clearance::Constraints::SignedIn.new do
     root to: "articles#new", as: :signed_in_root
   end

--- a/spec/system/clearance/visitor_updates_password_spec.rb
+++ b/spec/system/clearance/visitor_updates_password_spec.rb
@@ -36,7 +36,7 @@ RSpec.feature "Visitor updates password" do
 
   def visit_password_reset_page_for(user)
     visit edit_user_password_path(
-      user_id: user.id,
+      user_id: user,
       token: user.confirmation_token
     )
   end


### PR DESCRIPTION
Previously, when a user attempted to reset their password, they were unable to successfully change it. 
We have made changes to make it possible for a user to reset their password.
