### PR TITLE
Upgrade Circleci browser tools to 1.4.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  browser-tools: circleci/browser-tools@1.4.5
+  browser-tools: circleci/browser-tools@1.4.8
 
 references:
   install_bundler: &install_bundler


### PR DESCRIPTION
The circleci build was failing because the chrome version from browser tools 1.4.5 was causing an error: The requested URL returned error 404 for Chrome.
This was causing the build to not complete.
Browser tools 1.4.8 should fix the error.
