### PR TITLE
Remove Railtie deprecation message

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -7,7 +7,7 @@ require "rails/all"
 Bundler.require(*Rails.groups)
 
 if ["development", "test"].include? ENV["RAILS_ENV"]
-  Dotenv::Railtie.load
+  Dotenv::Rails.load
 end
 
 module Rumblr


### PR DESCRIPTION
The message below was coming up when a spec was run;
Dotenv::Railtie is deprecated! Use Dotenv::Rails instead.

This change helps to solve this.
