### PR TITLE
Style comment view

### DIFF
--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -12,8 +12,9 @@
         <%= link_to "Edit", edit_article_path(@article),
                     class: "purple-btn w-96" %>
       <% end %>
-      <br>
-      <%= render partial: "comments/comment", locals: { comment: @comment } %>
     </div>
+      <div class="mt-4">
+        <%= render partial: "comments/comment", locals: { comment: @comment } %>
+      </div>
   </div>
 </div>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -12,25 +12,40 @@
         </div>
 
       <% end %>
-      <%= f.text_area :body, placeholder: "Add a comment" %>
+      <%= f.text_area :body, rows: "6", placeholder: "Add a comment",
+        class: %w(w-full h-32 mt-2 p-3 rounded-lg focus:outline-none
+        focus:shadow-outline") %>
       <%= f.hidden_field :article_id, value: comment.article.id %>
-      <div>
-        <%= f.submit "Submit", class: "purple-btn w-66" %>
+      <div class="space-y-4 flex text-center">
+        <%= f.submit "Submit", class: "purple-btn w-96" %>
       </div>
     <% end %>
   <% else %>
-    <p class="text-gray-700"><%= link_to "Signin to add a comment", sign_in_path %></p>
+    <p class="text-gray-700">
+      <%= link_to "Signin to add a comment", sign_in_path %>
+    </p>
   <% end %>
   <% if comment.present? %>
-    <p class="font-bold uppercase text-xl"> Comments </p>
-    <div class="comments">
+    <div class="max-w-2xl mx-auto px-4 mt-5">
+      <div class="flex justify-between items-center mb-6">
+        <p class="text-lg lg:text-2xl font-bold text-gray-900 dark:text-white
+          -ml-4">
+          Comments
+        </p>
+      </div>
+    </div>
+    <div class="comments -mt-6">
       <% comment.article.comments.each do |comment| %>
-        <div>
+        <div class="flex justify items-center mb-2">
           <%= comment.user.name %>
+        </div>
+        <div class="flex justify text-gray-500 dark:text-gray-400 mb-2
+          border-b border-gray-200 dark:border-gray-700 dark:bg-gray-900">
           <%= comment.body %>
-          <% if comment.user.id == current_user.id %>
-            <%= link_to "Edit", edit_comment_path(comment) %>
-          <% end %>
+        <% if comment.user.id == current_user.id %>
+          <%= link_to "Edit", edit_comment_path(comment), class:
+            "hover:text-purple-500 hover:underline ml-2" %>
+        <% end %>
         </div>
       <% end %>
     </div>

--- a/app/views/comments/edit.html.erb
+++ b/app/views/comments/edit.html.erb
@@ -1,1 +1,5 @@
-<%= render partial: "comment", locals: { comment: @comment } %>
+<div class="relative py-3 mx-auto max-w-lg my-4">
+  <div class="max-w-lg rounded overflow-hidden shadow-lg p-20 mb-80">
+    <%= render partial: "comment", locals: { comment: @comment } %>
+  </div>
+</div>

--- a/app/views/comments/new.html.erb
+++ b/app/views/comments/new.html.erb
@@ -1,1 +1,5 @@
-<%= render partial: "comment", locals: { comment: @comment } %>
+<div class="relative py-3 mx-auto max-w-lg my-4">
+  <div class="max-w-lg rounded overflow-hidden shadow-lg p-20 mb-80">
+    <%= render partial: "comment", locals: { comment: @comment } %>
+  </div>
+</div>


### PR DESCRIPTION
The view that allows a user to provide feedback on a specific post was looking awful.
It has been styled to look more pleasant and to have a consistent user experience.

Comment view before
![Comment View before](https://github.com/user-attachments/assets/bc2ee179-9bf4-4194-8462-dc1b45654971)

Comment view after
![Comment View after](https://github.com/user-attachments/assets/0c144b22-0833-4783-bb2b-cabcc082bfbc)

