### PR TITLE
Handle unsuccessful comment edit

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -21,7 +21,13 @@ class CommentsController < ApplicationController
   def update
     @comment = Comment.find(params[:id])
     if @comment.update(comment_params)
-      redirect_to @comment.article, notice: t(".success")
+      if @comment.previously_changed?
+        redirect_to @comment.article, notice: t(".no_edit")
+      else
+        redirect_to @comment.article, notice: t(".success")
+      end
+    else
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -3,4 +3,7 @@ class Comment < ApplicationRecord
   belongs_to :article
 
   validates :body, presence: true
+  def previously_changed?
+    previous_changes.empty?
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,5 +70,6 @@ en:
       cannot_create: "Comment can't be blank"
     update:
       success: "Comment was updated successfully"
+      no_edit: "No changes were made to the comment"
     comment:
       edit: "Edit"

--- a/spec/system/author_visits_the_home_page_spec.rb
+++ b/spec/system/author_visits_the_home_page_spec.rb
@@ -85,4 +85,15 @@ RSpec.describe "Author visits the home page" do
       end
     end
   end
+
+  context "author attempts to edit their comment but changes their mind" do
+    it "shows the unedited comment with a flash" do
+      user = create(:user)
+      comment = create(:comment)
+      visit edit_comment_path(comment, as: user)
+      click_button "Submit"
+
+      expect(page).to have_content "No changes were made to the comment"
+    end
+  end
 end


### PR DESCRIPTION
Previously, the update logic did not account for cases where a comment edit was unsuccessful and this would result in errors and missing to provide feedback to the user.
This refactor ensures that the failed comment edits are properly handled.
This provides a better user experience and better error management.
