### PR TITLE
Enable comment deletion by the user

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -31,6 +31,13 @@ class CommentsController < ApplicationController
     end
   end
 
+  def destroy
+    @comment = Comment.find(params[:id])
+    @article = @comment.article
+    @comment.destroy
+    redirect_to @article, notice: t(".comment_deleted")
+  end
+
   private
 
   def comment_params

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -45,6 +45,9 @@
         <% if comment.user_id == current_user.id %>
           <%= link_to t(".edit"), edit_comment_path(comment), class:
             "hover:text-purple-500 hover:underline ml-2" %>
+          <%= link_to t(".delete"), comment_path(comment),
+            data: {"turbo-method": :delete},
+            class: "hover:text-purple-500 hover:underline ml-2" %>
         <% end %>
         </div>
       <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,3 +73,6 @@ en:
       no_edit: "No changes were made to the comment"
     comment:
       edit: "Edit"
+      delete: "Delete"
+    destroy:
+      comment_deleted: "Comment was successfully deleted"

--- a/spec/system/author_visits_the_home_page_spec.rb
+++ b/spec/system/author_visits_the_home_page_spec.rb
@@ -96,4 +96,20 @@ RSpec.describe "Author visits the home page" do
       expect(page).to have_content "No changes were made to the comment"
     end
   end
+
+  context "author deletes their comment" do
+    it "should delete the comment" do
+      user = create(:user)
+      comment = create(:comment, user: user)
+      visit article_path comment.article, as: user
+      within(".comments") do
+        expect(page).to have_content comment.body
+        click_link "Delete"
+      end
+      expect(page).to have_content "Comment was successfully deleted"
+      within(".comments") do
+        expect(page).not_to have_content comment.body
+      end
+    end
+  end
 end


### PR DESCRIPTION
Previously, users could not delete comments they had added to a post.
This update introduces functionality allowing users to delete their own comments.
