### PR TITLE
Refactor comments view to support dark mode

### DIFF
--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -28,8 +28,7 @@
   <% if comment.present? %>
     <div class="max-w-2xl mx-auto px-4 mt-5">
       <div class="flex justify-between items-center mb-6">
-        <p class="text-lg lg:text-2xl font-bold text-gray-900 dark:text-white
-          -ml-4">
+        <p class="text-lg lg:text-2xl font-bold text-gray-900 -ml-4">
           Comments
         </p>
       </div>
@@ -39,8 +38,8 @@
         <div class="flex justify items-center mb-2">
           <%= comment.user.name %>
         </div>
-        <div class="flex justify text-gray-500 dark:text-gray-400 mb-2
-          border-b border-gray-200 dark:border-gray-700 dark:bg-gray-900">
+        <div class="flex justify text-gray-700 dark:text-gray-400 mb-2
+          border-b border-gray-200 dark:border-gray-700">
           <%= comment.body %>
         <% if comment.user_id == current_user.id %>
           <%= link_to t(".edit"), edit_comment_path(comment), class:


### PR DESCRIPTION
Previously, the comments view didn't properly account for dark mode, causing added comments to display poorly in this mode.
This refactor adjusts the comments view to ensure proper styling and readability when dark mode is enabled.
This improves the user experience.

Comments view before
![Dark-mode before](https://github.com/user-attachments/assets/801c8430-f5b7-48fd-9d44-f05c51638558)

Comments view after
![Dark-mode after](https://github.com/user-attachments/assets/dab296c5-b29b-4281-a24b-a8502f5264f3)
