### PR TITLE
Refactor article index and make article title clickable

### DIFF
--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -1,5 +1,6 @@
 <div class="max-w-lg rounded overflow-hidden shadow-xl p-10 mb-10">
-  <p class="text-xl font-bold mb-2"><%= article.title %> </p>
+  <p class="text-xl font-bold mb-2"><%= link_to article.title,
+    article_path(article) %> </p>
   <p class="text-gray-700"><%= article.content %> </p>
   <% if ArticlePolicy.new(current_user, article).edit? %>
     <p class="text-gray-700 float-right">

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,16 +1,5 @@
 <div class="relative py-3 mx-auto max-w-lg my-4">
   <% @articles.each do |article| %>
-    <div class="max-w-lg rounded overflow-hidden shadow-xl p-10 mb-10">
-      <p class="text-xl font-bold mb-2"><%= link_to article.title, article %></p>
-      <p class="text-gray-700"><%= article.content %></p>
-      <% if ArticlePolicy.new(current_user, article).edit? %>
-        <p class="text-gray-700 float-right">
-          <%= link_to t(".edit_article"), edit_article_path(article.id),
-          class: "border-b-2 border-purple-500 border-opacity-0
-          hover:border-opacity-100 hover:text-purple-500
-          duration-200 cursor-pointer active"%>
-        </p>
-      <% end %>
-    </div>
+    <%= render article %>
   <% end %>
 </div>


### PR DESCRIPTION
Refactored the article index to use the article partial, making the code cleaner and easier to maintain.
Article titles are now clickable, allowing users to view article details directly.
