### PR TITLE
Add author name and Time stamp to articles

### DIFF
--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -6,6 +6,11 @@
       </h1>
     </div>
 
+    <div class="text-sm">
+      <%= t(".by") %>
+      <span class="text-purple-500"><%= @article.user.name %></span>
+      <%= t(".published_on", date: @article.created_at.strftime("%B %d, %Y")) %>
+    </div>
     <p><%= @article.content %></p>
     <div class="space-y-4 flex text-center">
       <% if ArticlePolicy.new(current_user, @article).edit? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,8 @@ en:
       title: "Title:"
       article: "Article "
       content: "Content:"
+      by: "By"
+      published_on: "Published on %{date}"
     new:
       errors: 
         one: "1 error prohibited this article from being saved"

--- a/spec/system/user_creates_an_article_spec.rb
+++ b/spec/system/user_creates_an_article_spec.rb
@@ -39,4 +39,15 @@ RSpec.describe "User creates an article" do
       expect(page).to have_content "Content can't be blank"
     end
   end
+
+  it "displays the article's timestamp in the correct format" do
+    user = create(:user)
+    visit root_path(as: user)
+    fill_in "Title", with: "This is my awesome title"
+    fill_in "Content", with: "My awesome content"
+    click_button "Submit"
+
+    article = Article.last
+    expect(page).to have_content article.created_at.strftime("%B %d, %Y")
+  end
 end


### PR DESCRIPTION
We have added the author's name and the article's creation date to provide additional context and to improve the user's understanding of the article's origin.
